### PR TITLE
upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin@sha256:d19c17f59e768549cd3d26f577be73b5e26e652dd66210d91a6738a355aa1dfe
 
 WORKDIR /app
 EXPOSE 8088

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.11.0</version>
         <configuration>
           <source>11</source>
           <target>11</target>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>2.2.0</uid2-shared.version>
+    <uid2-shared.version>2.3.10-7b7a07fbe9</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.uid2</groupId>
   <artifactId>uid2-core</artifactId>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
**Changes**
- use eclipse-temurin:11.0.18_10-jre-alpine
- consume uid2-shared:2.3.10-7b7a07fbe9 where there is upgraded jackson-databind