### PR TITLE
support azure-cc attestation provider in core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.uid2</groupId>
   <artifactId>uid2-core</artifactId>
-  <version>2.14.3-052166f931</version>
+  <version>2.14.5-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.uid2</groupId>
   <artifactId>uid2-core</artifactId>
-  <version>2.14.5-SNAPSHOT</version>
+  <version>2.14.3-052166f931</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>5.9.6-62621be878</uid2-shared.version>
+    <uid2-shared.version>5.13.0-a714a3ef26</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/src/main/java/com/uid2/core/Main.java
+++ b/src/main/java/com/uid2/core/Main.java
@@ -116,11 +116,11 @@ public class Main {
                 EnclaveIdentifierProvider enclaveIdProvider = new EnclaveIdentifierProvider(cloudStorage, enclaveMetadataPath);
                 enclaveRotatingVerticle = new RotatingStoreVerticle("enclaves", 60000, enclaveIdProvider);
 
+
+                var maaServerBaseUrl = ConfigStore.Global.getOrDefault(com.uid2.core.Const.Config.MaaServerBaseUrl, "https://sharedeus.eus.attest.azure.net");
                 AttestationService attestationService = new AttestationService()
                         .with("trusted", new TrustedAttestationProvider())
-                        .with("azure-sgx", new AzureAttestationProvider(
-                                ConfigStore.Global.getOrDefault("maa_server_base_url", "https://sharedeus.eus.attest.azure.net"),
-                                WebClient.create(vertx)))
+                        .with("azure-sgx", new AzureAttestationProvider(maaServerBaseUrl, WebClient.create(vertx)))
                         .with("aws-nitro", new NitroAttestationProvider(new InMemoryAWSCertificateStore()));
 
                 // try read GoogleCredentials
@@ -136,6 +136,8 @@ public class Main {
                     attestationService
                             .with("gcp-vmid", new GcpVmidAttestationProvider(googleCredentials, enclaveParams));
                 }
+
+                attestationService.with("azure-cc", new AzureCCAttestationProvider(maaServerBaseUrl));
 
                 attestationService.with("gcp-oidc", new GcpOidcAttestationProvider());
 

--- a/src/main/java/com/uid2/core/Main.java
+++ b/src/main/java/com/uid2/core/Main.java
@@ -117,7 +117,7 @@ public class Main {
                 enclaveRotatingVerticle = new RotatingStoreVerticle("enclaves", 60000, enclaveIdProvider);
 
 
-                var maaServerBaseUrl = ConfigStore.Global.getOrDefault(com.uid2.core.Const.Config.MaaServerBaseUrl, "https://sharedeus.eus.attest.azure.net");
+                var maaServerBaseUrl = ConfigStore.Global.getOrDefault(com.uid2.core.Const.Config.MaaServerBaseUrlProp, "https://sharedeus.eus.attest.azure.net");
                 AttestationService attestationService = new AttestationService()
                         .with("trusted", new TrustedAttestationProvider())
                         .with("azure-sgx", new AzureAttestationProvider(maaServerBaseUrl, WebClient.create(vertx)))

--- a/src/main/resources/com.uid2.core/test/enclaves/enclaves.json
+++ b/src/main/resources/com.uid2.core/test/enclaves/enclaves.json
@@ -16,5 +16,11 @@
     "protocol": "gcp-oidc",
     "identifier": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     "created": 1620693995
+  },
+  {
+    "name": "debug-azure-cc",
+    "protocol": "azure-cc",
+    "identifier": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "created": 1620693995
   }
 ]

--- a/src/main/resources/com.uid2.core/test/operators/operators.json
+++ b/src/main/resources/com.uid2.core/test/operators/operators.json
@@ -27,6 +27,15 @@
     "key_salt": "WSwyr8znzT0Yj/QiSRGZlsPz2lUIfRuO5FSpl89biiI="
   },
   {
+    "key": "test-azure-key",
+    "name": "partner-azure@uid2.com",
+    "contact": "partner-azure@uid2.com",
+    "created": 1617149276,
+    "protocol": "azure-cc",
+    "key_hash": "9hmTDqMPlR7Y6mnCDKWFOWGCK8uepsg/s6pCHPCqL16ziQ8OvUSpTlqOERJJkcyvZLRShgNVbafPO66TH91Vkw==",
+    "key_salt": "VhOxETeT1+hvq8y2YRCpdcPg0JrHkBfZXI58twuohGY="
+  },
+  {
     "key": "trusted-partner-key",
     "name": "partner-trusted@uid2.com",
     "contact": "partner-trusted@uid2.com",


### PR DESCRIPTION
Verified locally.

Note:
 - change the "identifier" to ccepolicyhash.
 - MAA token runtime info in below format: (base64 the below format)
```
{
    "location": "East US", // region
    "publicKey": "abc" // publickey base64 string
}
```
