### PR TITLE
introduce logging for attestation failed by invalid operator key

### DIFF
--- a/src/main/java/com/uid2/core/handler/AttestationFailureHandler.java
+++ b/src/main/java/com/uid2/core/handler/AttestationFailureHandler.java
@@ -34,6 +34,9 @@ public class AttestationFailureHandler implements Handler<RoutingContext> {
         final OperatorKey operatorKey = profile instanceof OperatorKey ? (OperatorKey) profile : null;
 
         if (operatorKey == null) {
+            if (context.response().getStatusCode() == 401)  {
+                LOG.warn("Attestation failed. Reason={invalid operator key}");
+            }
             return;
         }
 


### PR DESCRIPTION
The purpose of this is to introduce logging that will allow us to differentiate between 401 failures in /attest. 