### PR TITLE
UID2-2799 Fix constructor for AzureCCCoreAttestationService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>7.1.12-SNAPSHOT</uid2-shared.version>
+    <uid2-shared.version>7.1.13-SNAPSHOT</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,18 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>7.1.0-8e67b3a537</uid2-shared.version>
+    <uid2-shared.version>7.1.12-SNAPSHOT</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
 
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>7.1.13-SNAPSHOT</uid2-shared.version>
+    <uid2-shared.version>7.2.0-41efc58fbf</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/src/main/java/com/uid2/core/Main.java
+++ b/src/main/java/com/uid2/core/Main.java
@@ -135,7 +135,7 @@ public class Main {
                 }
 
                 var maaServerBaseUrl = ConfigStore.Global.getOrDefault(com.uid2.core.Const.Config.MaaServerBaseUrlProp, "https://sharedeus.eus.attest.azure.net");
-                attestationService.with("azure-cc", new AzureCCCoreAttestationService(maaServerBaseUrl));
+                attestationService.with("azure-cc", new AzureCCCoreAttestationService(maaServerBaseUrl, ConfigStore.Global.get(Const.Config.CorePublicUrlProp)));
 
                 attestationService.with("gcp-oidc", new GcpOidcCoreAttestationService(corePublicUrl));
 


### PR DESCRIPTION
Tested working: https://github.com/IABTechLab/uid2-operator/actions/runs/7988442839/job/21813021975

Review in order of:
1. https://github.com/IABTechLab/uid2-shared/pull/183
2. https://github.com/IABTechLab/uid2-core/pull/91
3. https://github.com/IABTechLab/uid2-operator/pull/359

Also tested the attestation fails when providing operator a not verified url: https://github.com/IABTechLab/uid2-operator/actions/runs/7998034382/job/21843547141
![image](https://github.com/IABTechLab/uid2-operator/assets/11983300/3c035bd3-e38b-485c-b9d6-f397aeb55a96)

