### PR TITLE
Return the OptOut URL as part of the attestation response

### DIFF
--- a/conf/local-e2e-docker-config.json
+++ b/conf/local-e2e-docker-config.json
@@ -30,6 +30,6 @@
   "enforceJwt": false,
   "aws_kms_jwt_signing_key_id": "ff275b92-0def-4dfc-b0f6-87c96b26c6c7",
   "aws_kms_jwt_signing_public_keys": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmvwB41qI5Fe41PDbXqcX5uOvSvfKh8l9QV0O3M+NsB4lKqQEP0t1hfoiXTpOgKz1ArYxHsQ2LeXifX4uwEbYJFlpVM+tyQkTWQjBOw6fsLYK2Xk4X2ylNXUUf7x3SDiOVxyvTh3OZW9kqrDBN9JxSoraNLyfw0hhW0SHpfs699SehgbQ7QWep/gVlKRLIz0XAXaZNw24s79ORcQlrCE6YD0PgQmpI/dK5xMML82n6y3qcTlywlGaU7OGIMdD+CTXA3BcOkgXeqZTXNaX1u6jCTa1lvAczun6avp5VZ4TFiuPo+y4rJ3GU+14cyT5NckEcaTKSvd86UdwK5Id9tl3bQIDAQAB",
-  "core_public_url": "http://localhost:8088",
-  "optout_url": "http://localhost:8090"
+  "core_public_url": "http://core:8088",
+  "optout_url": "http://optout:8081"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>7.2.4-SNAPSHOT</uid2-shared.version>
+    <uid2-shared.version>7.3.0-0c9c5b24fe</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
     <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-    <uid2-shared.version>7.2.0-41efc58fbf</uid2-shared.version>
+    <uid2-shared.version>7.2.4-SNAPSHOT</uid2-shared.version>
     <image.version>${project.version}</image.version>
   </properties>
 

--- a/src/main/java/com/uid2/core/vertx/CoreVerticle.java
+++ b/src/main/java/com/uid2/core/vertx/CoreVerticle.java
@@ -247,6 +247,7 @@ public class CoreVerticle extends AbstractVerticle {
                     String attestationToken = encodeAttestationToken(rc, attestationResult, encryptedAttestationToken.getEncodedAttestationToken());
                     responseObj.put("attestation_token", attestationToken);
                     responseObj.put("expiresAt", encryptedAttestationToken.getExpiresAt());
+                    responseObj.put("optout_url", ConfigStore.Global.get(Const.Config.OptOutUrlProp));
 
                     try {
                         Map.Entry<String, String> tokens = getJWTTokens(rc, profile, operator, attestationResult.getEnclaveId(), encryptedAttestationToken.getExpiresAt());


### PR DESCRIPTION
The OptOut URL was already part of the config, so don't expect to have to change config.
All unit tests pass.
Local e2e tests pass. 
Added some Core tests to the e2e tests