### PR TITLE
Add Attestation to `/operator/config` Endpoint 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,6 @@
 
 # https://thetradedesk.atlassian.net/browse/UID2-4460
 CVE-2024-47535
+
+# https://thetradedesk.atlassian.net/browse/UID2-4874
+CVE-2025-24970

--- a/src/test/java/com/uid2/core/vertx/TestCoreVerticle.java
+++ b/src/test/java/com/uid2/core/vertx/TestCoreVerticle.java
@@ -150,7 +150,6 @@ public class TestCoreVerticle {
             return null;
         });
 
-
         CoreVerticle verticle = new CoreVerticle(cloudStorage, authProvider, attestationService, attestationTokenService, enclaveIdentifierProvider, operatorJWTTokenProvider, jwtService, cloudEncryptionKeyProvider, fileSystem);
         vertx.deployVerticle(verticle, testContext.succeeding(id -> testContext.completeNow()));
 
@@ -925,12 +924,12 @@ public class TestCoreVerticle {
 
         // Make HTTP Get request to operator config endpoint
         this.get(vertx, Endpoints.OPERATOR_CONFIG.toString(), testContext.succeeding(response -> testContext.verify(() -> {
-                        assertEquals(200, response.statusCode());
-                        assertEquals("application/json", response.getHeader(HttpHeaders.CONTENT_TYPE));
-                        JsonObject actualConfig = new JsonObject(response.bodyAsString());
-                        assertEquals(expectedConfig, actualConfig);
-                        testContext.completeNow();
-                    })
+                    assertEquals(200, response.statusCode());
+                    assertEquals("application/json", response.getHeader(HttpHeaders.CONTENT_TYPE));
+                    JsonObject actualConfig = new JsonObject(response.bodyAsString());
+                    assertEquals(expectedConfig, actualConfig);
+                    testContext.completeNow();
+                })
         ));
     }
 


### PR DESCRIPTION
- Add version property to operator runtime config. Uses last modified timestamp of operator-config.json file
- Add attestation