### PR TITLE
upgrade vertx from 4.5.13 to 4.5.18 due to CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
 
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
         <vertx-maven-plugin.version>1.0.22</vertx-maven-plugin.version>
         <micrometer.version>1.12.2</micrometer.version>
         <junit-jupiter.version>5.10.3</junit-jupiter.version>
@@ -24,7 +24,7 @@
         <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-        <uid2-shared.version>10.8.6</uid2-shared.version>
+        <uid2-shared.version>10.9.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
 


### PR DESCRIPTION
also upgrade uid2-shared to 10.9.0 which has same vertx upgrade.