### PR TITLE
UID2-6717: Add /ops/operator_key_check endpoint for pre-startup validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
 COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
-RUN apk add --no-cache --upgrade libpng && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
+RUN apk add --no-cache --upgrade libpng gnutls && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
 USER uid2-core
 
 CMD java \

--- a/src/main/java/com/uid2/core/vertx/CoreVerticle.java
+++ b/src/main/java/com/uid2/core/vertx/CoreVerticle.java
@@ -221,6 +221,8 @@ public class CoreVerticle extends AbstractVerticle {
             .handler(auth.handleWithAudit(attestationMiddleware.handle(this::handlePartnerRefresh), List.of(Role.OPTOUT_SERVICE)));
         router.get(Endpoints.OPS_HEALTHCHECK.toString())
             .handler(this::handleHealthCheck);
+        router.get(Endpoints.OPERATOR_KEY_CHECK.toString())
+            .handler(auth.handleWithAudit(this::handleOperatorKeyCheck, List.of(Role.OPERATOR)));
         router.get(Endpoints.OPERATOR_CONFIG.toString())
             .handler(auth.handleWithAudit(attestationMiddleware.handle(this::handleGetConfig), List.of(Role.OPERATOR)));
 
@@ -267,6 +269,10 @@ public class CoreVerticle extends AbstractVerticle {
             resp.write(reason);
             resp.end();
         }
+    }
+
+    private void handleOperatorKeyCheck(RoutingContext rc) {
+        rc.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end("{\"status\":\"ok\"}");
     }
 
     private void handleAttestAsync(RoutingContext rc) {

--- a/src/main/java/com/uid2/core/vertx/Endpoints.java
+++ b/src/main/java/com/uid2/core/vertx/Endpoints.java
@@ -21,7 +21,8 @@ public enum Endpoints {
     SERVICE_LINKS_REFRESH("/service_links/refresh"),
     OPERATORS_REFRESH("/operators/refresh"),
     PARTNERS_REFRESH("/partners/refresh"),
-    OPERATOR_CONFIG("/operator/config");
+    OPERATOR_CONFIG("/operator/config"),
+    OPERATOR_KEY_CHECK("/ops/operator_key_check");
 
     private final String path;
 

--- a/src/test/java/com/uid2/core/vertx/CoreVerticleTest.java
+++ b/src/test/java/com/uid2/core/vertx/CoreVerticleTest.java
@@ -895,6 +895,28 @@ public class CoreVerticleTest {
 
     @Test
     @Tag("dontForceJwt")
+    void operatorKeyCheckReturns200ForValidOperatorKey(Vertx vertx, VertxTestContext testContext) {
+        fakeAuth(Role.OPERATOR);
+        this.get(vertx, Endpoints.OPERATOR_KEY_CHECK.toString(), testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(200, response.statusCode());
+            assertEquals("application/json", response.getHeader(HttpHeaders.CONTENT_TYPE));
+            assertEquals("{\"status\":\"ok\"}", response.bodyAsString());
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @Tag("dontForceJwt")
+    void operatorKeyCheckReturns401ForUnknownKey(Vertx vertx, VertxTestContext testContext) {
+        when(authProvider.get(any())).thenReturn(null);
+        this.get(vertx, Endpoints.OPERATOR_KEY_CHECK.toString(), testContext.succeeding(response -> testContext.verify(() -> {
+            assertEquals(401, response.statusCode());
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @Tag("dontForceJwt")
     void getConfigSuccess(Vertx vertx, VertxTestContext testContext) {
         JsonObject expectedConfig = new JsonObject(operatorConfig);
 


### PR DESCRIPTION
## Summary

- Adds `GET /ops/operator_key_check` to `uid2-core` — a lightweight endpoint that authenticates the operator Bearer token (requires `Role.OPERATOR`) without needing a full attestation payload
- Registers the route in `CoreVerticle` alongside `/ops/healthcheck`, without the attestation middleware
- Supports the companion change in `uid2-operator` ([IABTechLab/uid2-operator](https://github.com/IABTechLab/uid2-operator)) that calls this endpoint before starting the enclave, enabling fast-fail on misconfigured operator keys

**Jira:** [UID2-6717](https://thetradedesk.atlassian.net/browse/UID2-6717)

## Why

Currently, an invalid `core_api_token` is only discovered during the first attestation call — which happens asynchronously after the enclave has started. The operator then waits up to 12 hours before shutting down, with no actionable error message. This change provides a dedicated, low-cost endpoint that the operator can call synchronously at startup to validate its key before proceeding.

**Deployment note:** Deploy `uid2-core` (this PR) before the companion `uid2-operator` PR. The operator handles a 404 from this endpoint gracefully (logs a warning, continues) for backward compatibility during rolling deploys.

## Test plan

- [x] `CoreVerticleTest#operatorKeyCheckReturns200ForValidOperatorKey` — valid OPERATOR key → 200
- [x] `CoreVerticleTest#operatorKeyCheckReturns401ForUnknownKey` — unknown/missing key → 401
- [x] Full `CoreVerticleTest` suite passes (100 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)