### PR TITLE
UID2-6905: upgrade libcrypto3/libssl3 to fix CVE-2026-28390 (HIGH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
 COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
-RUN apk add --no-cache --upgrade libpng && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
+RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
 USER uid2-core
 
 CMD java \


### PR DESCRIPTION
## Summary

Fixes CVE-2026-28390 (HIGH severity) — OpenSSL Denial of Service via NULL pointer dereference in `libcrypto3`.

- **Vulnerable package:** `libcrypto3` / `libssl3` (Alpine)
- **Vulnerable version:** `3.5.5-r0`
- **Fixed version:** `3.5.6-r0`
- **Jira:** https://thetradedesk.atlassian.net/browse/UID2-6905

## Change

Added `libcrypto3 libssl3` to the `apk upgrade` call in `Dockerfile` so the patched Alpine packages are installed at image build time.

## Test plan

- [ ] CI vulnerability scan passes (Trivy no longer reports CVE-2026-28390)
- [ ] Build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)