### PR TITLE
UID2-7008: Suppress CVE-2026-33845 in .trivyignore — gnutls not used by our service

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,6 +5,9 @@
 # gnutls DoS vulnerability via crafted ClientHello - not impactful as gnutls is not used by our Java service
 # See: UID2-6655
 CVE-2026-1584 exp:2026-08-27
+# gnutls DoS vulnerability via DTLS zero-length record - not impactful as gnutls is not used by our Java service
+# See: UID2-7008
+CVE-2026-33845 exp:2026-11-04
 
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 
+# CVE-2026-33845: upgrade gnutls to 3.8.13-r0+
+RUN apk upgrade --no-cache gnutls
+
 WORKDIR /app
 EXPOSE 8088
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 
-# CVE-2026-33845: upgrade gnutls to 3.8.13-r0+
-RUN apk upgrade --no-cache gnutls
+# CVE-2026-33845: pin gnutls to 3.8.13-r0 (fixes DoS via DTLS zero-length record)
+RUN apk add --no-cache 'gnutls=3.8.13-r0'
 
 WORKDIR /app
 EXPOSE 8088

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 
-# CVE-2026-33845: pin gnutls to 3.8.13-r0 (fixes DoS via DTLS zero-length record)
-RUN apk add --no-cache 'gnutls=3.8.13-r0'
-
 WORKDIR /app
 EXPOSE 8088
 


### PR DESCRIPTION
## Summary

- Adds CVE-2026-33845 to `.trivyignore` with expiry 2026-11-04
- CVE-2026-33845 is a HIGH severity gnutls DoS vulnerability via DTLS (TLS over UDP) zero-length record
- gnutls is present in the Alpine 3.23 base image as a system library but is not used by our service — the JVM handles all TLS via JSSE, not gnutls, and none of our services use DTLS or UDP-based TLS. Confirmed by searching the repo — no references to gnutls in source code, dependencies, or configuration.
- Consistent with the existing suppression of CVE-2026-1584 (another gnutls DoS, UID2-6655)

## Jira

[UID2-7008](https://thetradedesk.atlassian.net/browse/UID2-7008)