### PR TITLE
UID2-7030: Upgrade gnutls + netty (CVE-2026-3833 + 4 netty CVEs)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,16 +2,15 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/
 # for more details
 
-# gnutls DoS vulnerability via crafted ClientHello - not impactful as gnutls is not used by our Java service
-# See: UID2-6655
-CVE-2026-1584 exp:2026-08-27
-# gnutls DoS vulnerability via DTLS zero-length record - not impactful as gnutls is not used by our Java service
-# See: UID2-7008
-CVE-2026-33845 exp:2026-11-04
-# gnutls DoS vulnerability via heap buffer overflow in DTLS handshake - not impactful as gnutls is not used by our Java service
-# See: UID2-7012
-CVE-2026-33846 exp:2026-11-05
-
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670
 GHSA-72hv-8253-57qq exp:2026-09-01
+
+# CVE-2026-42577 — netty-transport-native-epoll DoS via RST on half-closed TCP connection.
+# Advisory: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p
+# Server-side bug; netty maintainers backported the fix only to 4.2.13.Final and we run on
+# vert.x 4 / netty 4.1.x. This service sits behind authenticated load balancers (mTLS / API
+# gateway) so anonymous external attackers cannot reach the netty epoll socket directly;
+# LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
+# Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
+CVE-2026-42577 exp:2026-06-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
 COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 
-RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
+RUN apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils gnutls && adduser -D uid2-core && mkdir -p /app && chmod 705 -R /app && mkdir -p /app/file-uploads && chmod 777 -R /app/file-uploads && mkdir -p /app/pod_terminating && chmod 777 -R /app/pod_terminating
 USER uid2-core
 
 CMD java \

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
         <uid2-shared.version>11.4.16</uid2-shared.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
 


### PR DESCRIPTION
## Summary

Bundled vulnerability fixes:

* **gnutls** upgraded to 3.8.13-r0 in the Docker image — fixes [CVE-2026-3833](https://avd.aquasec.com/nvd/cve-2026-3833) and obsoletes 3 prior `.trivyignore` entries (CVE-2026-1584 / 33845 / 33846), all of which are also fixed by 3.8.13-r0.
* **netty** bumped 4.1.132.Final → 4.1.133.Final — fixes CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587.
* **CVE-2026-42577** (`netty-transport-native-epoll` epoll DoS, server-side) suppressed in `.trivyignore` until 2026-06-08. No 4.1.x patch backported by upstream; service is behind authenticated LB so the attack surface is limited; CVSS impact is Availability-only.

Per-CVE Jira tickets:
* gnutls upgrade: [UID2-7030](https://thetradedesk.atlassian.net/browse/UID2-7030)
* CVE-2026-42583: [UID2-7031](https://thetradedesk.atlassian.net/browse/UID2-7031)
* CVE-2026-42579: [UID2-7032](https://thetradedesk.atlassian.net/browse/UID2-7032)
* CVE-2026-42584: [UID2-7033](https://thetradedesk.atlassian.net/browse/UID2-7033)
* CVE-2026-42587: [UID2-7034](https://thetradedesk.atlassian.net/browse/UID2-7034)
* CVE-2026-42577 (suppression): [UID2-7035](https://thetradedesk.atlassian.net/browse/UID2-7035)

## Test plan
- [ ] Trivy CI passes (or only flags expected suppressions)
- [ ] Build and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)