### PR TITLE
UID2-4739: use DefaultCredentialsProvider for KMS client in JWTTokenProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-        <uid2-shared.version>11.5.1-alpha-352-SNAPSHOT</uid2-shared.version>
+        <uid2-shared.version>11.6.0</uid2-shared.version>
         <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-core</artifactId>
-    <version>2.30.127</version>
+    <version>2.30.128-alpha-186-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <vertx.verticle>com.uid2.core.vertx.CoreVerticle</vertx.verticle>
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
-        <uid2-shared.version>11.4.16</uid2-shared.version>
+        <uid2-shared.version>11.5.1-alpha-352-SNAPSHOT</uid2-shared.version>
         <netty.version>4.1.133.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
         <uid2-shared.version>11.5.1-alpha-352-SNAPSHOT</uid2-shared.version>
+        <lombok.version>1.18.36</lombok.version>
         <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
@@ -82,6 +83,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.uid2</groupId>
             <artifactId>uid2-shared</artifactId>
@@ -209,6 +216,13 @@
         <configuration>
           <source>21</source>
           <target>21</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
         <uid2-shared.version>11.5.1-alpha-352-SNAPSHOT</uid2-shared.version>
-        <lombok.version>1.18.36</lombok.version>
         <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
@@ -83,12 +82,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>com.uid2</groupId>
             <artifactId>uid2-shared</artifactId>
@@ -216,13 +209,6 @@
         <configuration>
           <source>21</source>
           <target>21</target>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>org.projectlombok</groupId>
-              <artifactId>lombok</artifactId>
-              <version>${lombok.version}</version>
-            </path>
-          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/uid2/core/service/JWTTokenProvider.java
+++ b/src/main/java/com/uid2/core/service/JWTTokenProvider.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
@@ -154,7 +154,7 @@ public class JWTTokenProvider {
                 throw e;
             }
         } else {
-            WebIdentityTokenFileCredentialsProvider credentialsProvider = WebIdentityTokenFileCredentialsProvider.create();
+            DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
 
             client = kmsClientBuilder
                     .region(Region.of(region))

--- a/src/main/java/com/uid2/core/service/MetadataProvider.java
+++ b/src/main/java/com/uid2/core/service/MetadataProvider.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 
 import static com.uid2.core.util.MetadataHelper.*;
 
-@Getter
 public abstract class MetadataProvider {
     private final ICloudStorage metadataStreamProvider;
     private final ICloudStorage downloadUrlGenerator;

--- a/src/main/java/com/uid2/core/service/MetadataProvider.java
+++ b/src/main/java/com/uid2/core/service/MetadataProvider.java
@@ -8,7 +8,6 @@ import com.uid2.shared.store.scope.GlobalScope;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import lombok.Getter;
 
 import static com.uid2.core.util.MetadataHelper.*;
 


### PR DESCRIPTION
## Summary

`JWTTokenProvider` explicitly constructs `WebIdentityTokenFileCredentialsProvider` for KMS access, which ties it to OIDC/IRSA. Switching to `DefaultCredentialsProvider` makes it compatible with EKS Pod Identity, instance profiles, and any future credential mechanism — matching the standard AWS SDK v2 best practice of letting the credential chain resolve at runtime.

- Replace `WebIdentityTokenFileCredentialsProvider.create()` with `DefaultCredentialsProvider.create()` in the non-static-credentials branch of `getKmsClient`
- Update the corresponding import

Companion fix to `CloudStorageS3.java` (UID2-4739).

## Test plan
- [ ] Verify existing IRSA-based environments continue to work (DefaultCredentialsProvider falls through to the web identity token file provider in its chain)
- [ ] Update trust policies of EKS cluster to Pod Identity (not IRSA) and verify KMS signing succeeds
- [ ] Verify static-credentials path (accessKeyId/secretAccessKey set in config) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)