### PR TITLE
UID2-7278: upgrade Netty to 4.1.135.Final (CVE-2026-44249/45416/45674/47691)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,4 +13,4 @@ GHSA-72hv-8253-57qq exp:2026-09-01
 # gateway) so anonymous external attackers cannot reach the netty epoll socket directly;
 # LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
-CVE-2026-42577 exp:2026-06-08
+CVE-2026-42577 exp:2026-09-11

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <launcher.class>io.vertx.core.Launcher</launcher.class>
 
         <uid2-shared.version>11.4.16</uid2-shared.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- **Netty upgrade** (UID2-7278): bump `netty.version` from `4.1.133.Final` → `4.1.135.Final` in `pom.xml`. Fixes 4 HIGH CVEs: CVE-2026-44249 (netty-handler IPv6 filter bypass), CVE-2026-45416 (netty-handler SNI DoS), CVE-2026-45674 (netty-resolver-dns DNS cache poisoning), CVE-2026-47691 (netty-resolver-dns NS bailiwick bypass).
- **CVE-2026-42577 expiry extended**: `2026-06-08` → `2026-09-11` (3 months; no 4.1.x fix available per UID2-7035).

## Jira
- [UID2-7278](https://thetradedesk.atlassian.net/browse/UID2-7278)

## Test plan
- [ ] CI vulnerability scan passes (Trivy no longer flags CVE-2026-44249/45416/45674/47691)
- [ ] Unit tests pass