### PR TITLE
UID2-7364: Suppress CVE-2026-54512 / CVE-2026-54513 (jackson-databind)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,11 @@ GHSA-72hv-8253-57qq exp:2026-09-01
 # LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
+
+# jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
+# jackson-databind is pulled in transitively via uid2-shared; the version fix is tracked in
+# uid2-shared (https://github.com/IABTechLab/uid2-shared/pull/631) and will flow here on the
+# next uid2-shared release. Suppressing in the interim.
+# See: UID2-7364
+CVE-2026-54512 exp:2026-07-25
+CVE-2026-54513 exp:2026-07-25


### PR DESCRIPTION
## UID2-7364: Suppress jackson-databind CVE-2026-54512 / CVE-2026-54513

The scheduled vulnerability scan flagged two HIGH CVEs in `com.fasterxml.jackson.core:jackson-databind`:

- **CVE-2026-54512** (HIGH) — jackson-databind general-purpose data-binding
- **CVE-2026-54513** (HIGH) — jackson-databind general-purpose data-binding

### Impact
jackson-databind is pulled in **transitively via `uid2-shared`** in this repo (not a direct dependency). The version fix is owned and tracked in **uid2-shared** ([PR #631](https://github.com/IABTechLab/uid2-shared/pull/631), bumping to 2.19.0) and will flow into this repo automatically on the next `uid2-shared` release bump.

### Decision
Suppress both CVEs in `.trivyignore` (expiry **2026-07-25**, 1 month) in the interim. No fixed version is available in a compatible jackson line yet (upstream fix targets are 2.18.8 / 2.21.4 / 3.1.4); the real version fix arrives via the `uid2-shared` release. This matches the approach approved in uid2-shared PR #631.

Tracked in UID2-7364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
