### PR TITLE
UID2-7376: suppress CVE-2026-2100 (p11-kit) — not exploitable

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,11 @@ CVE-2026-42577 exp:2026-09-11
 # See: UID2-7364
 CVE-2026-54512 exp:2026-07-25
 CVE-2026-54513 exp:2026-07-25
+
+# CVE-2026-2100 — p11-kit NULL dereference via C_DeriveKey in the Alpine base image.
+# uid2-core is a pure Java service; the JVM uses JSSE for TLS and the bundled Java cacerts keystore for trust — it does
+# not load the native p11-kit PKCS#11 module loader and never calls C_DeriveKey, so the
+# vulnerable code path is not reachable. Fixed in Alpine v3.23 >= 0.26.2-r0 but the pinned
+# eclipse-temurin base image has not yet been rebuilt with it.
+# See: UID2-7376
+CVE-2026-2100 exp:2026-09-01


### PR DESCRIPTION
## Summary
Suppresses **CVE-2026-2100** (HIGH) — a NULL pointer dereference in `p11-kit` (Alpine base image) via `C_DeriveKey` — in `.trivyignore`, with an expiry of 2026-09-01.

## Why suppress rather than upgrade
This service is pure Java. The JVM uses JSSE for TLS and the bundled Java `cacerts` keystore for trust validation — it never loads the native `p11-kit` PKCS#11 module loader and never calls `C_DeriveKey`, so the vulnerable code path is not reachable. The package is present only as a transitive dependency of the Alpine base image.

This follows the team's established treatment for non-exploitable native base-image CVEs (cf. `CVE-2026-45447` libcrypto3, already suppressed here with the same 'JVM uses JSSE, not the native lib' rationale). A fix exists in Alpine v3.23 (`>= 0.26.2-r0`) but the pinned `eclipse-temurin` base image has not yet been rebuilt with it; the expiry resurfaces this for review once that lands. Suppression is self-cleaning, whereas a manual `apk --upgrade` line would become silent dead weight once the base image catches up.

Jira: UID2-7376