### PR TITLE
[TICKET]: suppress CVE-2026-45447 in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,10 @@ CVE-2026-56408 exp:2026-08-09
 # jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
 # (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
 GHSA-r7wm-3cxj-wff9 exp:2026-08-23
+
+# CVE-2026-45447 — openssl (libcrypto3 / libssl3, Alpine base image) (HIGH).
+# Not exploitable here: Dockerfile:19 apk adds libcrypto3/libssl3; no
+# tcnative/conscrypt/bouncycastle in pom.xml and no openssl/pkcs7/OpenSsl refs in any *.java —
+# pure-Java Vert.x uses JSSE
+# See: [TICKET]
+CVE-2026-45447 exp:2026-09-04


### PR DESCRIPTION
## CVE-2026-45447 — suppress in `.trivyignore`

Jira: _ticket pending — the title and the `# See:` line in the entry are backfilled once it exists_

Adds a `.trivyignore` entry with expiry **2026-09-04** (1 month). No code fix: the vulnerable code path is not reachable from this service, and reachability alone determines suppress-vs-fix — a fixed version existing upstream does not change that.

Change the expiry in review if you want a different window.

### Triage report

# CVE-2026-45447 — triage report

- Triaged: 2026-08-04T05:11:44Z
- Model: general_use_claude-opus-4-8
- Verdict: not_affected
- Repos: uid2-core

# CVE-2026-45447 — Impact Assessment (uid2-core)

## What the CVE is
CVE-2026-45447 is a **use-after-free (CWE-416)** in **OpenSSL**'s PKCS#7 signature-verification path (`PKCS7_verify()` in `crypto/pkcs7/pk7_smime.c`). When verifying a `SignedData` structure with an **empty `digestAlgorithms` ASN.1 SET**, OpenSSL mismanages ownership of the caller-supplied BIO chain and frees a BIO the application still owns. A subsequent `BIO_free()` in the calling application then operates on freed memory — resulting in process crash, heap corruption, or potentially remote code execution.

- **Severity:** HIGH (OpenSSL's 3.0.21 release notes list this as the release's most-severe fix, rated High).
- **Attack surface:** Only applications that link OpenSSL natively **and** pass attacker-controlled PKCS#7/S-MIME signed messages into the legacy PKCS#7 APIs. Applications using the CMS APIs and the FIPS modules are explicitly *not* affected. Mail gateways processing untrusted signed mail are the canonical at-risk case.
- **Fix:** OpenSSL added a `next`-tracking variable to preserve BIO chain boundaries; shipped upstream in the 3.0.21 / 3.5.x line (2026-06-09) and backported by distros (RHSA-2026:25237/25239/26275, SUSE-SU-2026:2412-1, and Alpine).

## Whether/how it affects our services
The vulnerable package **is present** in uid2-core's runtime image — `Dockerfile:19` runs `apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils gnutls` on the pinned `eclipse-temurin:21-jre-alpine-3.23` base. However, it is **not reachable** from our code:

1. **No native OpenSSL linkage.** `pom.xml` (and every pom in the tree) contains no `netty-tcnative`, `tomcat-native`, `conscrypt`, `bouncycastle`, or `wildfly-openssl` dependency. uid2-core is a pure-Java Vert.x service — TLS is handled by the **JVM's JSSE** stack, not native `libssl`/`libcrypto`.
2. **No PKCS#7 / S-MIME code.** Grep across `*.java`, `*.xml`, `*.json`, `*.properties` for `openssl|pkcs7|s/mime|smime|libssl|libcrypto|OpenSsl|io.netty.handler.ssl` returns **only** the Dockerfile `apk add` line — no source invokes `PKCS7_verify()` or any S/MIME verification.
3. **No JNI bridge.** There is no native binding through which uid2-core could invoke the vulnerable `libcrypto` routine.

Because the service never calls into native OpenSSL and never processes PKCS#7/S-MIME signed content, the use-after-free code path cannot be triggered. `libcrypto3`/`libssl3` sit in the image as inert base-image OS libraries.

## Decision
**Not affected → suppress in `.trivyignore`** (recommended expiry ≈ 1 month from today, e.g. 2026-09-04). This mirrors the treatment of **CVE-2026-2100** (p11-kit) already suppressed on this very branch (`swi-UID2-7376-p11-kit-cve-2026-2100`): an Alpine base-image native C library that is present but unreachable from a pure-Java service. The availability of a fixed OpenSSL package does not change the verdict — an unexploitable, unreachable CVE is suppressed rather than fixed. No dependency upgrade or code change is warranted; if desired, the suppression naturally clears when the pinned eclipse-temurin base image is rebuilt with the patched Alpine OpenSSL.

*(This run is read-only and autonomous: no branch, PR, `.trivyignore` edit, Jira ticket, or Slack post was created — the deliverable is this reachability verdict and report only.)*

**Sources:** [CVE Record](https://www.cve.org/CVERecord?id=CVE-2026-45447) · [SentinelOne — OpenSSL UAF](https://www.sentinelone.com/vulnerability-database/cve-2026-45447/) · [SUSE advisory](https://www.suse.com/security/cve/CVE-2026-45447.html) · [Penligent technical writeup](https://www.penligent.ai/hackinglabs/cve-2026-45447/)


---
_Opened by uid2-vul-scan-agent. Verdict confidence: high. Please sanity-check the reachability argument before approving._
